### PR TITLE
Add BSDS500 as a submodule (see comment)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "BSDS500"]
+	path = BSDS500
+	url = https://github.com/BIDS/BSDS500.git


### PR DESCRIPTION
Since we are using the BSDS500 repo for our dataset and the benchmarking code, we should either:

1. Add the BSDS500 project as a git submodule (this PR). This will allow us to put all our work in one repo - no need to clone and work with 2 different repos.
2. Fork the BSDS500 to our organization's (CS-6476-project) GitHub account, and then download it locally as another repo while working on our project.
3. Just copy the relevant code and images from the BSDS500 repo, add it to our repo and ensure proper credits are given.

Lmk your thoughts!